### PR TITLE
Adding Makefile to build Patrao using `make`. Plus CircleCI integration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+
+jobs:
+  build-from-source:
+    working_directory: /go/github.com/nutanix/patrao
+    docker:
+    - image: circleci/golang:1.12
+    steps:
+    - checkout
+    - setup_remote_docker
+    - run: make image
+
+workflows:
+  version: 2
+  build-oscar:
+    jobs:
+      - build-from-source  

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+GIT_REPO=github.com/nutanix/patrao
+BIN_NAME=upgrade_agent
+IMG_NAME=patrao-upgrade-agent
+IMG_VERSION=latest
+rdir := $(dir $(lastword $(MAKEFILE_LIST)))
+
+.PHONY: clean binaries
+
+all: image
+
+binaries: $(rdir)/bin/$(BIN_NAME)
+
+image: binaries
+	-docker rmi $(IMG_NAME):$(IMG_VERSION) >/dev/null 2>&1
+	(docker build -t $(IMG_NAME):$(IMG_VERSION) -f $(rdir)/deployments/$(BIN_NAME)/Dockerfile .)
+
+$(rdir)/bin/$(BIN_NAME):
+	mkdir -p $(rdir)/bin
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ $(GIT_REPO)/cmd/$(BIN_NAME)
+
+clean:
+	-docker rmi $(IMG_NAME):$(IMG_VERSION)
+	rm -f $(rdir)/bin/$(BIN_NAME)

--- a/deployments/upgrade_agent/Dockerfile
+++ b/deployments/upgrade_agent/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.12.4
-
+FROM alpine:3.9.2
 
 WORKDIR /upgrade_agent
-
-COPY . ./upgrade_agent
+ADD bin/upgrade_agent .
+RUN apk add ca-certificates && update-ca-certificates
 
 # temporary value
 EXPOSE 1533
@@ -11,4 +10,4 @@ EXPOSE 1533
 # default poll interval is 30m
 ENV UPGRADE_AGENT_POLL_INTERVAL_S 1800
 
-CMD ["./upgrade_agent/upgrade_agent"]
+CMD ["./upgrade_agent"]


### PR DESCRIPTION
To build, run:

make
Currently the image created is patrao-upgrade-agent:latest. We may have to add additional tags before pushing to a repository.

Plus, all future merges become CircleCI enabled once this gets merged.